### PR TITLE
Add HF links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Page](https://img.shields.io/badge/Project-Website-pink?logo=googlechrome&logoColor=white)](https://lotus3d.github.io/)
 [![Paper](https://img.shields.io/badge/arXiv-Paper-b31b1b?logo=arxiv&logoColor=white)](https://arxiv.org/abs/2409.18124)
+[![HuggingFace Models](https://img.shields.io/badge/%F0%9F%A4%97-Models-yellow)](https://huggingface.co/models?search=jingheya/lotus)
 [![HuggingFace Demo](https://img.shields.io/badge/🤗%20HuggingFace-Demo%20(Depth)-yellow)](https://huggingface.co/spaces/haodongli/Lotus_Depth)
 [![HuggingFace Demo](https://img.shields.io/badge/🤗%20HuggingFace-Demo%20(Normal)-yellow)](https://huggingface.co/spaces/haodongli/Lotus_Normal)
 [![Replicate](https://replicate.com/chenxwh/lotus/badge?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAgAAAAIAAQAAAADcA+lXAAAAgUlEQVR4Ae3MURFAABQAsHcniCj6txBBAfgGAMAWYPE9AAAAAAAAAABZPW1DIBAIBAKBII8dBAKBQCAYCJJ6xI2BQCAQCASCKgb8OhAIBAJBWnc8IBAIBAKBQFBEn0AgEAgEAoFAIBAIBAKBQCAQCAQCgUAgEAj2AwAAAAAAAABoAC8mT5WJjIdGAAAAAElFTkSuQmCC)](https://replicate.com/chenxwh/lotus)
@@ -85,10 +86,10 @@ pip install -r requirements.txt
 We offer four models in total, here are the corresponding configurations:
 |CHECKPOINT_DIR |TASK_NAME |MODE |
 |:--:|:--:|:--:|
-| `jingheya/lotus-depth-g-v1-0`| `depth`| `generation`|
-| `jingheya/lotus-depth-d-v1-0`| `depth`|`regression` |
-| `jingheya/lotus-normal-g-v1-0`|`normal` | `generation`|
-| `jingheya/lotus-normal-d-v1-0`|`normal` |`regression` |
+| [jingheya/lotus-depth-g-v1-0](https://huggingface.co/jingheya/lotus-depth-g-v1-0) | `depth`| `generation`|
+| [jingheya/lotus-depth-d-v1-0](https://huggingface.co/jingheya/lotus-depth-d-v1-0) | `depth`|`regression` |
+| [jingheya/lotus-normal-g-v1-0](https://huggingface.co/jingheya/lotus-normal-g-v1-0) |`normal` | `generation`|
+| [jingheya/lotus-normal-d-v1-0](https://huggingface.co/jingheya/lotus-normal-d-v1-0) |`normal` |`regression` |
 
 ## 🎓 Citation
 If you find our work useful in your research, please consider citing our paper:


### PR DESCRIPTION
Follow-up of #4 

This PR updates the model table to link to the corresponding models on the hub.

Btw, would be cool to group the models, demo and paper in a collection: https://huggingface.co/docs/hub/en/collections.